### PR TITLE
Add Mac Address Wifi Support

### DIFF
--- a/README
+++ b/README
@@ -10,13 +10,15 @@ _/    _/  _/    _/  _/        _/    _/  _/    _/  _/    _/    _/    _/    _/
 //  initiated by Yann Lechelle (cofounder Appsfire) on 8/28/11.
 //  Copyright 2011 OpenUDID.org
 //
-//  iOS / MacOS code: https://github.com/ylechelle/OpenUDID
-//  Android code: https://github.com/vieux/OpenUDID
+//  Master Branches
+//	iOS / MacOS code: https://github.com/ylechelle/OpenUDID
+//	Android code: https://github.com/vieux/OpenUDID
 //
 //  Contributors:
 //      https://github.com/ylechelle (initiator & iOS code)
-//      https://github.com/samrobbins (Mac OS port)
+//	https://github.com/kajinka13 (Obj-C ARC support)
 //      https://github.com/vieux (Android version)
+//      https://github.com/samrobbins (Mac OS port)
 
 Synopsis: an open source project to provide a universal and persistent
           Unique Device IDentifier (UDID) solution for iOS and Android


### PR DESCRIPTION
But adding the ability to create the UDID from wifi mac address, we would not have the guarantee of uniqueness? 
Going to replace the variable in _getOpenUDID 
const char \* cstr = [[[NSProcessInfo processInfo] globallyUniqueString] UTF8String];
 with a method that returns the mac address. 
I did a test and there are no problems. 
It all depends on if it comes out of the concept of OpenUDID. If interested I can provide the change.
