### PR TITLE
Fixes a crash when unarchiving a malformed archive from the pasteboard

### DIFF
--- a/OpenUDID.m
+++ b/OpenUDID.m
@@ -85,8 +85,14 @@ static int const kOpenUDIDRedundancySlots = 100;
 #else
 	id item = [pboard dataForType:kOpenUDIDDomain];
 #endif	
-    if (item)
-        item = [NSKeyedUnarchiver unarchiveObjectWithData:item];
+    if (item) {
+        @try{
+            item = [NSKeyedUnarchiver unarchiveObjectWithData:item];
+        } @catch(NSException* e) {
+            OpenUDIDLog(@"Unable to unarchive item %@ on pasteboard!", [pboard name]);
+            item = nil;
+        }
+    }
     
     // return an instance of a MutableDictionary 
     return [NSMutableDictionary dictionaryWithDictionary:(item == nil || [item isKindOfClass:[NSDictionary class]]) ? item : nil];


### PR DESCRIPTION
Suppose that a malicious application pollutes the pasteboard by doing something like the following:

```
// fills the pasteboard with bogus OpenUDID slot "dictionaries".
for(int n=0;n<100;n++)
{
    NSString* pbId = [NSString stringWithFormat:@"org.OpenUDID.slot.%d", n];
    UIPasteboard* pb = [UIPasteboard pasteboardWithName:pbId create:NO];
    if(pb)
        [pb setValue:[[NSArray new] autorelease] forPasteboardType:@"org.OpenUDID"];
}
```

Any application that uses OpenUDID would then crash when it attempts to unarchive one of these values from the pasteboard when doing the frequency check, inside of _getDictFromPasteboard:

OpenUDID.m, line 79:

```
// Retrieve an NSDictionary from a pasteboard of a given type
// Convenience method to support iOS & Mac OS X
//
+ (NSMutableDictionary*) _getDictFromPasteboard:(id)pboard {
#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR 
    id item = [pboard dataForPasteboardType:kOpenUDIDDomain];
#else
    id item = [pboard dataForType:kOpenUDIDDomain];
#endif  
    if (item)
        item = [NSKeyedUnarchiver unarchiveObjectWithData:item]; // EXCEPTION THROWN HERE <----

    // return an instance of a MutableDictionary 
    return [NSMutableDictionary dictionaryWithDictionary:(item == nil || [item isKindOfClass:[NSDictionary class]]) ? item : nil];
}
```

This vulnerability means that someone can write malicious code in their application that causes other applications to crash.

This pull request fixes this problem by surrounding the call to "NSKeyedUnarchiver unarchiveObjectWithData:" with a @try block.
