### PR TITLE
Adds application's GUID to user defaults

### DIFF
--- a/OpenUDID.m
+++ b/OpenUDID.m
@@ -293,8 +293,10 @@ static int const kOpenUDIDRedundancySlots = 100;
 
     // Save the dictionary locally if applicable
     //
-    if (localDict && saveLocalDictToDefaults)
+    if (localDict && saveLocalDictToDefaults) {
         [defaults setObject:localDict forKey:kOpenUDIDKey];
+        [defaults setObject:guuid forKey:kAppGUUID];
+    }
 
     // If the UIPasteboard externa representation marks this app as opted-out, then to respect privacy, we return the ZERO OpenUDID, a sequence of 40 zeros...
     // This is a *new* case that developers have to deal with. Unlikely, statistically low, but still.


### PR DESCRIPTION
Right now, OpenUDID tries to read the application's GUID from the shared user defaults. If the application's GUID isn't found, OpenUDID generates a new one, **BUT** **it never saves it**. That means that when the user runs the application OpenUDID will generate a new application GUID (and therefore a new UDID) **every time**.

This pull request fixes this problem by saving the application's GUID to the user's defaults.
