### PR TITLE
Use ARC

### DIFF
--- a/OpenUDID.h
+++ b/OpenUDID.h
@@ -45,26 +45,6 @@
 #define kOpenUDIDErrorOptedOut      1
 #define kOpenUDIDErrorCompromised   2
 
-//
-// Support for ARC
-//
-
-#if __has_feature(objc_arc)
-
-#define HAS_ARC 1
-#define RETAIN(_o) (_o)
-#define RELEASE(_o) 
-#define AUTORELEASE(_o) (_o)
-
-#else
-
-#define HAS_ARC 0
-#define RETAIN(_o) [(_o) retain]
-#define RELEASE(_o) [(_o) release]
-#define AUTORELEASE(_o) [(_o) autorelease]
-
-#endif
-
 @interface OpenUDID : NSObject {
 }
 + (NSString*) value;

--- a/OpenUDID.m
+++ b/OpenUDID.m
@@ -33,6 +33,10 @@
  SOFTWARE.
 */
 
+#if ! __has_feature(objc_arc)
+#error This file requires ARC to be enabled. Either enable ARC for the entire project or use -fobjc-arc flag.
+#endif
+
 #import "OpenUDID.h"
 #import <CommonCrypto/CommonDigest.h> // Need to import for CC_MD5 access
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
@@ -175,7 +179,7 @@ static int const kOpenUDIDRedundancySlots = 100;
     {
       //generate a new uuid and store it in user defaults
       CFUUIDRef uuid = CFUUIDCreate(NULL);
-      guuid = (NSString *) CFUUIDCreateString(NULL, uuid);
+      guuid = (__bridge_transfer NSString *) CFUUIDCreateString(NULL, uuid);
       CFRelease(uuid);
     }
   
@@ -312,7 +316,7 @@ static int const kOpenUDIDRedundancySlots = 100;
                                                      code:kOpenUDIDErrorOptedOut
                                                  userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:@"Application with GUUID %@ is opted-out from OpenUDID as of %@",guuid,optedOutDate],@"description", nil]];
             
-        kOpenUDIDSessionCache = RETAIN(([NSString stringWithFormat:@"%040x",0]));
+        kOpenUDIDSessionCache = ([NSString stringWithFormat:@"%040x",0]);
         return kOpenUDIDSessionCache;
     }
 
@@ -328,7 +332,7 @@ static int const kOpenUDIDRedundancySlots = 100;
                                          code:kOpenUDIDErrorNone
                                      userInfo:[NSDictionary dictionaryWithObjectsAndKeys:@"OpenUDID succesfully retrieved",@"description", nil]];
     }
-    kOpenUDIDSessionCache = RETAIN(openUDID);
+    kOpenUDIDSessionCache = openUDID;
     return kOpenUDIDSessionCache;
 }
 


### PR DESCRIPTION
This commit does a few things:

1) Removes the horrid `#define`s from the header.
2) Forces the user to use ARC for this file by erroring if the user doesn't have ARC enabled.
3) Adds in a required `__bridge_transfer` for a `CFStringRef` cast to `NSString*`.
