### PR TITLE
Remove bridged cast (__bridge_transfer NSString *) from non-ARC project

### DIFF
--- a/OpenUDID.m
+++ b/OpenUDID.m
@@ -184,7 +184,7 @@ static int const kOpenUDIDRedundancySlots = 100;
     {
       //generate a new uuid and store it in user defaults
       CFUUIDRef uuid = CFUUIDCreate(NULL);
-      guuid = (__bridge_transfer NSString *) CFUUIDCreateString(NULL, uuid);
+      guuid = (NSString *) CFUUIDCreateString(NULL, uuid);
       CFRelease(uuid);
     }
   


### PR DESCRIPTION
It doesn't appear that the __bridge_transfer cast is necessary now that the project no longer requires ARC.  This impacts older versions of Xcode and prohibits those users from using projects that incorporate OpenUDID.
