### PR TITLE
Use self instead of OpenUDID for library integrators

### DIFF
--- a/OpenUDID.m
+++ b/OpenUDID.m
@@ -155,7 +155,7 @@ static int const kOpenUDIDRedundancySlots = 100;
 // Otherwise, it will register the current app and return the OpenUDID
 //
 + (NSString*) value {
-    return [OpenUDID valueWithError:nil];
+    return [self valueWithError:nil];
 }
 
 + (NSString*) valueWithError:(NSError **)error {
@@ -218,7 +218,7 @@ static int const kOpenUDIDRedundancySlots = 100;
             // assign availableSlotPBid to be the first one available
             if (availableSlotPBid==nil) availableSlotPBid = slotPBid;
         } else {
-            NSDictionary* dict = [OpenUDID _getDictFromPasteboard:slotPB];
+            NSDictionary* dict = [self _getDictFromPasteboard:slotPB];
             NSString* oudid = [dict objectForKey:kOpenUDIDKey];
             OpenUDIDLog(@"SlotPB dict = %@",dict);
             if (oudid==nil) {
@@ -257,7 +257,7 @@ static int const kOpenUDIDRedundancySlots = 100;
             // this is the case where this app instance is likely to be the first one to use OpenUDID on this device
             // we create the OpenUDID, legacy or semi-random (i.e. most certainly unique)
             //
-            openUDID = [OpenUDID _generateFreshOpenUDID];
+            openUDID = [self _generateFreshOpenUDID];
         } else {
             // or we leverage the OpenUDID shared by other apps that have already gone through the process
             // 
@@ -302,7 +302,7 @@ static int const kOpenUDIDRedundancySlots = 100;
         // Save the local dictionary to the corresponding UIPasteboard slot
         //
         if (openUDID && localDict)
-            [OpenUDID _setDict:localDict forPasteboard:slotPB];
+            [self _setDict:localDict forPasteboard:slotPB];
     }
 
     // Save the dictionary locally if applicable
@@ -343,7 +343,7 @@ static int const kOpenUDIDRedundancySlots = 100;
 + (void) setOptOut:(BOOL)optOutValue {
 
     // init call
-    [OpenUDID value];
+    [self value];
     
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 


### PR DESCRIPTION
Those integrating OpenUDID into a library now only
have to add their prefix to the OpenUDID class name
in 3 places instead of half a dozen.
